### PR TITLE
Update usage test

### DIFF
--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1,16 +1,16 @@
 exports[`main tool should display help 1`] = `
 "
-Usage:index[options]
+ Usage: index [options]
 
 
-Options:
+ Options:
 
--V,--versionoutputtheversionnumber
---no-color
---debugging
--d,--dir<dir>Thedirectorywheretosavetheflowresultanderrors.Ifnotspecifiednofileswillbesaved.
--f,--file<filename>Nameoftheresultfile.defaultsto\'results.txt\'
--e,--error-file<filename>Nameofthefilewhereparsingerrorsarestored.defaultsto\'error.txt\'
--h,--helpoutputusageinformation
+ -V, --version output the version number
+ --no-color 
+ --debugging 
+ -d, --dir <dir> The directory where to save the flow result and errors. If not specified no files will be saved.
+ -f, --file <filename> Name of the result file. defaults to \'results.txt\'
+ -e, --error-file <filename> Name of the file where parsing errors are stored. defaults to \'error.txt\'
+ -h, --help output usage information
 "
 `;

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1,0 +1,16 @@
+exports[`main tool should display help 1`] = `
+"
+Usage:index[options]
+
+
+Options:
+
+-V,--versionoutputtheversionnumber
+--no-color
+--debugging
+-d,--dir<dir>Thedirectorywheretosavetheflowresultanderrors.Ifnotspecifiednofileswillbesaved.
+-f,--file<filename>Nameoftheresultfile.defaultsto\'results.txt\'
+-e,--error-file<filename>Nameofthefilewhereparsingerrorsarestored.defaultsto\'error.txt\'
+-h,--helpoutputusageinformation
+"
+`;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -4,24 +4,9 @@ const createChecker = require('../checker')
 
 describe('main tool', () => {
   it('should display help', () => {
-    const expected = `
-      Usage: index [options]
-
-      Options:
-
-        -h, --help                   output usage information
-        -V, --version                output the version number
-        --no-color
-        --debugging
-        -d, --dir <dir>              The directory where to save the flow result and errors. If not specified no files will be saved.
-        -f, --file <filename>        Name of the result file. defaults to 'results.txt'
-        -e, --error-file <filename>  Name of the file where parsing errors are stored. defaults to 'error.txt'
-
-    `
-
     const { stdout } = spawnSync('node', ['index.js', '--help'], { encoding: 'utf8' })
 
-    expect(stdout.replace(/ /g, '')).toEqual(expected.replace(/ /g, ''))
+    expect(stdout.replace(/ /g, '')).toMatchSnapshot();
   })
 
   it('should find no errors in `index.js`', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,15 +6,15 @@ describe('main tool', () => {
   it('should display help', () => {
     const { stdout } = spawnSync('node', ['index.js', '--help'], { encoding: 'utf8' })
 
-    expect(stdout.replace(/ /g, '')).toMatchSnapshot();
+    expect(stdout.replace(/ +/g, ' ')).toMatchSnapshot();
   })
 
   it('should find no errors in `index.js`', () => {
     const expected = `Found 0 errors
-    `
+`
 
     const { stdout } = spawnSync('flow', ['check'], { encoding: 'utf8' })
 
-    expect(stdout.replace(/ /g, '')).toEqual(expected.replace(/ /g, ''))
+    expect(stdout.replace(/ +/g, ' ')).toEqual(expected.replace(/ +/g, ' '))
   })
 })


### PR DESCRIPTION
Also switches to snapshots for the usage text because the usage text can be changed by upstream and it’s easier to be able to do [`jest --updateSnapshot`](https://facebook.github.io/jest/docs/snapshot-testing.html) and review than manually update it.

Also changes normalization to normalize spaces to one space instead of the empty string to make the snapshot more readable.