### PR TITLE
Ensure that result checker processes complete data

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,4 +3,13 @@
 const checker = require('./checker')()
 
 process.stdin.setEncoding('utf8')
-process.stdin.on('data', (stdout) => checker({ stdout }))
+
+const data = [];
+process.stdin.on('readable', () => {
+	data.push(process.stdin.read());
+});
+
+process.stdin.on('end', () => {
+	console.log({data});
+	checker({ stdout: data.join('') });
+});

--- a/index.js
+++ b/index.js
@@ -10,6 +10,5 @@ process.stdin.on('readable', () => {
 });
 
 process.stdin.on('end', () => {
-	console.log({data});
 	checker({ stdout: data.join('') });
 });


### PR DESCRIPTION
On long output, consuming data immediately can result in processing partial output and getting false (and weird) positives.